### PR TITLE
fix: remove unnecessary/buggy naming code 

### DIFF
--- a/DatabaseSchemaReader/CodeGen/Namer.cs
+++ b/DatabaseSchemaReader/CodeGen/Namer.cs
@@ -203,11 +203,6 @@ namespace DatabaseSchemaReader.CodeGen
                 }
             }
 
-            if (table.ForeignKeys.Count(x => x.RefersToTable == targetTable) > 1)
-            {
-                name = string.Join("", foreignKey.Columns.Select(x => table.FindColumn(x).NetName).ToArray());
-            }
-
             return NameCollection(name);
         }
     }


### PR DESCRIPTION
The code was previously dormant, but was activated by introduction of additional FKs in the DB schema on the CustomerUser table (namely FKs to itself for created and last updated IDs).