### PR TITLE
fix: data reader uses column names now instead of ordinal position

### DIFF
--- a/DatabaseSchemaReader/CodeGen/RepositoryImplementationWriter.cs
+++ b/DatabaseSchemaReader/CodeGen/RepositoryImplementationWriter.cs
@@ -940,14 +940,20 @@ namespace DatabaseSchemaReader.CodeGen
         {
             foreach (var c in table.Columns)
             {
+                var leftHandSideComponent = $"{entityVariableName}.{CodeWriterUtils.GetPropertyNameForDatabaseColumn(c)} = ";
+                var getValueFromReaderComponent = $"reader[\"{c.Name}\"]";
+                var castAsColumnDataTypeComponent = $"({CodeWriterUtils.FindDataType(c)})";
+                string line;
                 if (c.Nullable)
                 {
-                    classBuilder.AppendLine($"{entityVariableName}.{CodeWriterUtils.GetPropertyNameForDatabaseColumn(c)} = reader.GetValue({c.Ordinal - 1}) == DBNull.Value ? null : ({CodeWriterUtils.FindDataType(c)})reader.GetValue({c.Ordinal - 1});");
+                    line = $"{leftHandSideComponent}{getValueFromReaderComponent} == DBNull.Value ? null : {castAsColumnDataTypeComponent}{getValueFromReaderComponent};";
                 }
                 else
                 {
-                    classBuilder.AppendLine($"{entityVariableName}.{CodeWriterUtils.GetPropertyNameForDatabaseColumn(c)} = ({CodeWriterUtils.FindDataType(c)})reader.GetValue({c.Ordinal - 1});");
+                    line = $"{leftHandSideComponent}{castAsColumnDataTypeComponent}{getValueFromReaderComponent};";
                 }
+
+                classBuilder.AppendLine(line);
             }
         }
     }


### PR DESCRIPTION
Fixing autogen code for retrieving column values from data reader. It used to use column ordinal position, but a bug was exposed when migration scripts altered an existing table to remove columns in the middle of the table. The column positions do not get renumbered in PostgreSQL, and our code was indexing to the wrong columns. Now it uses column names.