### PR TITLE
feat(all): Move housekeeping logic from services to generated data access code

### DIFF
--- a/DatabaseSchemaReader/CodeGen/DataAnnotationWriter.cs
+++ b/DatabaseSchemaReader/CodeGen/DataAnnotationWriter.cs
@@ -47,6 +47,11 @@ namespace DatabaseSchemaReader.CodeGen
             {
                 cb.AppendLine($"[DatabaseGenerated(DatabaseGeneratedOption.Computed)]");
             }
+		
+		    if (!string.IsNullOrEmpty(column.Description) && column.Description.StartsWith("[") && column.Description.EndsWith("]"))
+		    {
+			    cb.AppendLine( column.Description );
+		    }
         }
 
         private void WriteColumnAttribute(ClassBuilder cb, string name)

--- a/DatabaseSchemaReader/CodeGen/RepositoryImplementationWriter.cs
+++ b/DatabaseSchemaReader/CodeGen/RepositoryImplementationWriter.cs
@@ -406,17 +406,7 @@ namespace DatabaseSchemaReader.CodeGen
                 CodeWriterUtils.WriteEntryLogging(classBuilder, methodSignature);
                 WriteGetPropertyColumnPairs();
 
-                var clause = "var setClause = string.Join(\", \", propertyColumnPairs.Select(pcp => $\"{pcp.Value} = @{pcp.Key.Name}\"))";
-                if (table.Columns.Any(c => c.Name == "DeletedTimestamp" ) )
-                {
-                    classBuilder.AppendLine(clause);
-                    classBuilder.AppendLine("                      .Replace(\"@DeletedTimestamp\", entity.DeletedTimestamp == null ? \"null\" : \"LEAST(@DeletedTimestamp, c.\\\"DeletedTimestamp\\\")\")");
-                }
-                else
-                {
-                    classBuilder.AppendLine($"{clause};");
-                }
-
+                classBuilder.AppendLine("var setClause = string.Join(\", \", propertyColumnPairs.Select(pcp => $\"{pcp.Value} = @{pcp.Key.Name}\"));");
                 var thisTableAlias = codeWriterSettings.Namer.NameToAcronym(table.Name);
                 if (!string.IsNullOrEmpty(fromClause))
                 {


### PR DESCRIPTION
Changes to generated repository methods:

1. Never update CreatedUserID fields
2. Do not perform the update if the request's LastUpdatedTimestamp is before the database's value
3. Allow soft-deleted records to be updated (or NOP re-deleted without an error)
4. Set DeletedTimestamp based on the request and the current database value